### PR TITLE
Updated link to the Github profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ We are a bunch of developers who believe in open source and love to develop and 
 <li><a href="http://opensource.jiitu.org/wiki">wiki</a></li>
 <li><a href="http://twitter.com/#!/JIITOSDC">Twitter </a></li>
 <li><a href="https://www.facebook.com/groups/jiitlug/">Facebook</a> </li>
-<li><a href="https://github.com/organizations/osdc">Github</a></li>
+<li><a href="https://github.com/osdc">Github</a></li>
 <li><a href="http://opensource.jiitu.org/wiki/index.php?title=Projects">Projects</a></li>
 </ul>
 


### PR DESCRIPTION
original - https://github.com/organizations/osdc
new - https://github.com/osdc

github.com/organizations doesn't seem to exist anymore (http 404).
